### PR TITLE
fix: Fix movie name not matched due to lower and upper case

### DIFF
--- a/src/components/DiscoverPane.tsx
+++ b/src/components/DiscoverPane.tsx
@@ -837,7 +837,7 @@ export default class DiscoverPane extends Component<{globalState: {state: any}}>
 
 						const movies = await search(name);
 						
-						const movie = movies.find(x => x.title === name);
+						const movie = movies.find(x => x.title.toLowerCase() === name.toLowerCase());
 						
 						return movie.tmdbUrl;
 						


### PR DESCRIPTION
This PR fixes the `movie is undefined` issue, because movie names are not matched, further due to a mixture of upper case and lower cases.

But there are still other errors that need to be fixed afterwards.